### PR TITLE
Update Fritsla names

### DIFF
--- a/data/101/817/157/101817157.geojson
+++ b/data/101/817/157/101817157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000393,
-    "geom:area_square_m":2606912.746168,
+    "geom:area_square_m":2606912.746169,
     "geom:bbox":"12.773167909,57.5427773536,12.8085133191,57.5689320311",
     "geom:latitude":57.554623,
     "geom:longitude":12.789349,
@@ -21,6 +21,9 @@
         "Fritsla"
     ],
     "name:eng_x_preferred":[
+        "Fritsla"
+    ],
+    "name:eng_x_variant":[
         "Frissla"
     ],
     "name:fre_x_preferred":[
@@ -108,7 +111,7 @@
     "wof:lang":[
         "swe"
     ],
-    "wof:lastmodified":1529702228,
+    "wof:lastmodified":1559152879,
     "wof:name":"Fritsla",
     "wof:parent_id":1125358449,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1623

Moves existing preferred name to a variant, updates the preferred name to match the `wof:name`. No PIP required.