### PR TITLE
Fix locality name in SE

### DIFF
--- a/data/101/839/549/101839549.geojson
+++ b/data/101/839/549/101839549.geojson
@@ -30,10 +30,10 @@
         "Ursviken"
     ],
     "name:eng_x_preferred":[
-        "Ursvik"
+        "Ursviken"
     ],
     "name:eng_x_variant":[
-        "Ursviken"
+        "Ursvik"
     ],
     "name:fra_x_preferred":[
         "Ursviken"
@@ -119,7 +119,7 @@
     "wof:lang":[
         "swe"
     ],
-    "wof:lastmodified":1566642254,
+    "wof:lastmodified":1568059999,
     "wof:name":"Ursviken",
     "wof:parent_id":1125417517,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1700

- Swaps variant and preferred names for the locality of Ursviken, Sweden

No PIP required, can merge once approved.

See: https://sv.wikipedia.org/wiki/Ursviken